### PR TITLE
Exclude ExoPlayer submodule from Gradle update action

### DIFF
--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -18,3 +18,4 @@ jobs:
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:
           repo-token: ${{ secrets.JF_BOT_TOKEN }}
+          paths-ignore: ExoPlayer/**


### PR DESCRIPTION
The update workflow previously failed due to it trying to update the wrapper of the ExoPlayer submodule. Adding the submodule to the list of ignored paths fixes the issue.