### PR TITLE
Enable submodules support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,10 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"github>jellyfin/.github//renovate-presets/gradle",
-		":semanticCommitsDisabled"
-	]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>jellyfin/.github//renovate-presets/gradle",
+    ":semanticCommitsDisabled"
+  ],
+  "git-submodules": {
+    "enabled": true
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,16 @@
   ],
   "git-submodules": {
     "enabled": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchManagers": [
+        "git-submodules"
+      ],
+      "addLabels": [
+        "ci",
+        "submodules"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Currently in beta, thus requires explicit opt-in:
https://docs.renovatebot.com/modules/manager/git-submodules/