### PR TITLE
Ignore errors when generating Javadoc

### DIFF
--- a/exoplayer-ffmpeg-extension/build.gradle.kts
+++ b/exoplayer-ffmpeg-extension/build.gradle.kts
@@ -10,10 +10,12 @@ val android = exoplayerProject.extensions.findByType(LibraryExtension::class.jav
     ?: error("Could not find android extension")
 
 val generateJavadoc by exoplayerProject.tasks.getting(Javadoc::class)
+generateJavadoc.isFailOnError = false
+
 val javadocJar by tasks.creating(Jar::class) {
     archiveClassifier.set("javadoc")
-    dependsOn(generateJavadoc)
     from(generateJavadoc)
+    dependsOn(generateJavadoc)
 }
 
 // Package sources from ExoPlayer FFmpeg extension project


### PR DESCRIPTION
Some files from the ExoPlayer core and common modules are missing from the classpath, this doesn't actually impact the generated Javadoc though.