### PR TITLE
Set minSdk to 23 (Android 6.0)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,11 +24,11 @@ allprojects {
         google()
     }
 
-    // Set minSdk to 21 and force a specific NDK version
+    // Set minSdk to 23 and force a specific NDK version
     afterEvaluate {
         val android = extensions.findByType(LibraryExtension::class.java)
         if (android != null) {
-            android.defaultConfig.minSdk = 21
+            android.defaultConfig.minSdk = 23
             android.ndkVersion = "26.1.10909125"
         }
     }

--- a/build.sh
+++ b/build.sh
@@ -16,4 +16,4 @@ ln -sf "${FFMPEG_PATH}" "${FFMPEG_MOD_PATH}/jni/ffmpeg"
 
 # Start build
 cd "${FFMPEG_MOD_PATH}/jni"
-./build_ffmpeg.sh "${FFMPEG_MOD_PATH}" "${ANDROID_NDK_PATH}" "linux-x86_64" 21 "${ENABLED_DECODERS[@]}"
+./build_ffmpeg.sh "${FFMPEG_MOD_PATH}" "${ANDROID_NDK_PATH}" "linux-x86_64" 23 "${ENABLED_DECODERS[@]}"


### PR DESCRIPTION
This is now the minimum SDK version required by upstream.