### PR TITLE
build: Enable iamf and mpegh codec

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ export ANDROID_NDK_PATH=$ANDROID_HOME/ndk/26.1.10909125
 export ANDROIDX_MEDIA_ROOT="${PWD}/media"
 export FFMPEG_MOD_PATH="${ANDROIDX_MEDIA_ROOT}/libraries/decoder_ffmpeg/src/main"
 export FFMPEG_PATH="${PWD}/ffmpeg"
-export ENABLED_DECODERS=(flac alac pcm_mulaw pcm_alaw mp3 aac ac3 eac3 dca mlp truehd)
+export ENABLED_DECODERS=(flac alac pcm_mulaw pcm_alaw mp3 aac ac3 eac3 dca mlp truehd iamf mpegh)
 
 # Create softlink to ffmpeg
 ln -sf "${FFMPEG_PATH}" "${FFMPEG_MOD_PATH}/jni/ffmpeg"


### PR DESCRIPTION
enable build iamf and mpeg-h spatial-audio codecs formats